### PR TITLE
Add installation guide

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,7 +19,7 @@
 .. toctree::
    :maxdepth: 1
    :hidden:
-   
+   Installation <source/getting_started/installation>
    Getting Started <source/getting_started/idx_getting_started>
    User Guide <source/user_guide/idx_user_guide>
    API Reference <source/reference_API/idx_reference_API>

--- a/docs/source/getting_started/idx_getting_started.rst
+++ b/docs/source/getting_started/idx_getting_started.rst
@@ -7,6 +7,7 @@ Getting Started
    :maxdepth: 1
    :hidden:
    
+   Installation <installation>
    Loading Data <loading>
    Integration <integration>
    Custom Analysis <learning-to-fly>

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -1,0 +1,22 @@
+.. _installation:
+
+Installation
+============
+
+You can install PyHyperScattering from PyPI using ``pip``:
+
+.. code-block:: bash
+
+   pip install PyHyperScattering
+
+The project defines a number of optional dependency groups in
+``pyproject.toml``.  These extras can be installed using the standard
+``pip`` extras syntax.  For example, to install the optional
+``grazing`` dependencies run:
+
+.. code-block:: bash
+
+   pip install PyHyperScattering[grazing]
+
+Consult ``pyproject.toml`` for additional groups such as ``bluesky`` or
+``ui`` if you need those capabilities.

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -18,5 +18,16 @@ The project defines a number of optional dependency groups in
 
    pip install PyHyperScattering[grazing]
 
-Consult ``pyproject.toml`` for additional groups such as ``bluesky`` or
-``ui`` if you need those capabilities.
+The available extras include:
+
+* ``grazing`` – packages for grazing-incidence scattering analysis
+* ``bluesky`` – integrate with ``bluesky`` data sources like ``tiled``
+* ``performance`` – acceleration packages such as ``pyopencl`` and ``dask``
+* ``ui`` – interactive plotting tools including ``holoviews`` and ``hvplot``
+* ``doc`` – dependencies needed to build the documentation
+* ``dev`` – development utilities (linters, build helpers)
+* ``test`` – full test suite requirements
+* ``all-nogpu`` – everything except GPU-related packages
+* ``all`` – install every optional dependency
+
+Refer to ``pyproject.toml`` for the exact list of packages in each group.


### PR DESCRIPTION
## Summary
- document how to install PyHyperScattering via pip
- describe installing optional extras
- link installation page from project index and getting started index

## Testing
- `pytest -q` *(fails: FileNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68479ea152fc832b9134627e3327233f