### PR TITLE
Add docs for example data archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This is a package approaching scope-completeness, but still under extremely acti
 
 The (quite incomplete) documentation is located at https://pages.nist.gov/PyHyperScattering, and the tutorials in the repository are occasionally helpful.  Several core developers are active on the NIST RSoXS slack, Nikea, and NSLS2 slacks and welcome DMs with questions, or email Peter Beaucage.
 
+Example data used in the tutorials and tests can be downloaded from our [GitHub release](https://github.com/usnistgov/PyHyperScattering/releases/tag/0.0.0-example-data).  See [Obtaining Example Data](docs/source/getting_started/example_data.rst) for more information.
+
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/usnistgov/PyHyperScattering/HEAD)
 ![Unit Tests](https://github.com/usnistgov/PyHyperScattering/actions/workflows/main.yml/badge.svg)
 ![CodeQL](https://github.com/usnistgov/PyHyperScattering/actions/workflows/codeql-analysis.yml/badge.svg)

--- a/docs/source/getting_started/example_data.rst
+++ b/docs/source/getting_started/example_data.rst
@@ -1,0 +1,14 @@
+.. _example_data:
+
+Obtaining Example Data
+======================
+
+Several tutorials and the unit tests expect example data files to be available in
+this repository. These files are provided as a separate archive on GitHub.
+
+Download the data archives from the `0.0.0-example-data` release:
+https://github.com/usnistgov/PyHyperScattering/releases/tag/0.0.0-example-data
+
+After downloading, unzip the archives in the repository root so that directories
+such as ``Example/`` are created. The continuous integration tests also fetch
+these archives during setup, so your local tests will fail without them.

--- a/docs/source/getting_started/idx_getting_started.rst
+++ b/docs/source/getting_started/idx_getting_started.rst
@@ -11,6 +11,7 @@ Getting Started
    Integration <integration>
    Custom Analysis <learning-to-fly>
    Utilities <utilities>
+   Example Data <example_data>
 
 PyHyperScattering aims to make working with hyperspectral x-ray and neutron scattering data easy, to make programs that work with such data a combination of simple, logical commands with minimal 'cruft'.  In the era of modern computing, there is no reason you should have to think about for loops and how you're storing different intermediate data products - you should be able to go immediately from raw data to an analysis with clear commands, punch down to the data you need for your science quickly.  The goal is for these tools to make the mechanics of hyperspectral scattering easier and in so doing, more reproducible, explainable, and robust.
 

--- a/tutorial/Demo - XArrayResonantScattering.ipynb
+++ b/tutorial/Demo - XArrayResonantScattering.ipynb
@@ -271,7 +271,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A side warning here: if you are using my example data, at this point the memory usage will be kind of insane (~20 GB peak, about 15.5 GB at rest).  We can clean up by tossing the raw data and integrator, which will take us down to something ~2 GB:"
+    "A side warning here: if you are using my example data (see [Obtaining Example Data](../docs/source/getting_started/example_data.rst)), at this point the memory usage will be kind of insane (~20 GB peak, about 15.5 GB at rest).  We can clean up by tossing the raw data and integrator, which will take us down to something ~2 GB:"
    ]
   },
   {

--- a/tutorial/SST1 data tutorial.ipynb
+++ b/tutorial/SST1 data tutorial.ipynb
@@ -847,7 +847,7 @@
    "source": [
     "Now, from files:\n",
     "\n",
-    "You'll need to modify this path to some RSoXS data on disk.  If you don't have any, feel free to skip ahead, or download some from the example data pack on the GitHub repo (look under releases)."
+    "You'll need to modify this path to some RSoXS data on disk.  If you don't have any, feel free to skip ahead or download data from the [example data release](https://github.com/usnistgov/PyHyperScattering/releases/tag/0.0.0-example-data).  See [Obtaining Example Data](../docs/source/getting_started/example_data.rst) for details."
    ]
   },
   {


### PR DESCRIPTION
## Summary
- add instructions for downloading example data
- mention example data in README
- cross-link example data docs in tutorials

## Testing
- `pytest -q` *(fails: FileNotFoundError: 'Example/SST1/21792')*
- `pytest -q tests/test_autoversioning.py`

------
https://chatgpt.com/codex/tasks/task_e_68479ea423b8832ba20e4c85432330a6