### PR TITLE
Add docs on loader workflow

### DIFF
--- a/docs/source/getting_started/idx_getting_started.rst
+++ b/docs/source/getting_started/idx_getting_started.rst
@@ -31,7 +31,9 @@ The metadata should be loaded and converted to a standardized set of terms, inte
 
 :ref:`Integration <integration>`
 -----------------------------------
-Convert your data from pixel space or qx/qy space to chi-q space - perfect for slicing.  generally tools here are built on pyFAI, though some variants also use warp_polar from numpy.
+Convert your data from pixel space or qx/qy space to chi-q space - perfect for slicing.  Most integrators wrap `pyFAI <https://pyfai.readthedocs.io/>`_ but there are alternatives.
+The standard :class:`~PyHyperScattering.PFGeneralIntegrator` uses pyFAI's azimuthal integrator with a mask and calibration parameters.
+For grazing-incidence work :class:`~PyHyperScattering.PGGeneralIntegrator` relies on ``pygix`` and :class:`~PyHyperScattering.WPIntegrator` integrates ``qx``/``qy`` data with ``warp_polar``.
 
 
 :ref:`Custom Analysis <analysis>`

--- a/docs/source/getting_started/integration.rst
+++ b/docs/source/getting_started/integration.rst
@@ -3,3 +3,27 @@
 Integration: raw intensity to I(q)
 ====================================
 
+Raw detector images generally contain two pixel axes.  To visualize
+and analyze scattering patterns these need to be transformed into
+chi/q or qz/qxy coordinates.  PyHyperScattering wraps several
+integrators to accomplish this, with most implementations relying on
+`pyFAI <https://pyfai.readthedocs.io/>`_.
+
+``PFGeneralIntegrator`` provides a thin layer over pyFAI's azimuthal
+integrator.  Pass in calibration parameters or a ``.poni`` file and a
+mask, then call ``integrateImageStack`` to convert an xarray with
+``pix_x``/``pix_y`` axes to intensity in ``q`` and optionally ``chi``::
+
+   from PyHyperScattering.PFGeneralIntegrator import PFGeneralIntegrator
+   integrator = PFGeneralIntegrator(ponifile="calib.poni",
+                                   maskmethod="image", maskpath="mask.tif")
+   iq = integrator.integrateImageStack(raw_data)
+
+For grazing-incidence experiments ``PGGeneralIntegrator`` uses
+``pygix`` to output either reciprocal-space ``q_xy``/``q_z`` data or
+caked ``q`` vs ``chi``.  Datasets already in ``qx``/``qy`` coordinates
+can be integrated with ``WPIntegrator`` which relies on
+``skimage.transform.warp_polar`` (or its GPU version).
+
+All integrators return properly labeled xarray objects so the rest of
+the workflow can use normal xarray indexing and visualization.

--- a/docs/source/getting_started/loading.rst
+++ b/docs/source/getting_started/loading.rst
@@ -1,5 +1,42 @@
 .. _loading:
 
 Loading: getting your data into PyHyperScattering
-==============================================================
+=================================================
 
+PyHyperScattering organizes raw scattering images into `xarray` objects.
+Image reading is handled by subclasses of :class:`~PyHyperScattering.FileLoader.FileLoader`.
+The key method defined in ``FileLoader.py`` is ``loadFileSeries`` which
+converts a folder of detector files into a single DataArray.
+
+The simplified signature is::
+
+    def loadFileSeries(self, basepath, dims, coords={}, file_filter=None,
+                       md_filter={}, quiet=True, output_qxy=False,
+                       dest_qx=None, dest_qy=None, output_raw=False,
+                       image_slice=None):
+
+It walks a directory, loads each file with ``loadSingleImage`` and stacks
+frames along the requested dimensions.  Metadata keys listed in
+``md_filter`` must be present for a frame to be included.  The returned
+DataArray always contains ``pix_x`` and ``pix_y`` axes together with any
+additional dimensions discovered from metadata or ``coords``.
+
+Once an array is created you can write it to disk using the
+``fileio`` accessor defined in ``FileIO.py``.  This accessor provides
+convenience methods such as ``savePickle`` and ``saveNetCDF``::
+
+    loaded = loader.loadFileSeries(my_path, dims=["energy"]) 
+    loaded.fileio.saveNetCDF("run.nc")
+
+The same accessor can also export to NeXus or Zarr formats while taking
+care to sanitize attributes for serialization.
+
+For curve fitting the package offers a ``fit`` accessor
+implemented in ``Fitting.py``.  The ``apply`` method stacks all
+dimensions except the chosen fit axis, applies a user supplied function
+with progress bars, and returns the results as another xarray object::
+
+    result = data.fit.apply(PyHyperScattering.Fitting.fit_lorentz_bg)
+
+This design keeps reduction and analysis steps in the familiar xarray
+workflow while hiding repetitive boilerplate.


### PR DESCRIPTION
## Summary
- document how `FileLoader` turns raw files into `xarray` objects
- mention the `fileio` and `fit` accessors
- explain how pyFAI integrators convert pixel data to I(q)
- list the various integrator classes in the index

## Testing
- `pytest -q` *(fails: FileNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684798d3c5e0832baf3ad48961eba930