### PR TITLE
Add Lorentz fitting tests and handle stacked dims

### DIFF
--- a/src/PyHyperScattering/Fitting.py
+++ b/src/PyHyperScattering/Fitting.py
@@ -80,7 +80,7 @@ def fit_lorentz(x,guess=None,pos_int_override=False,silent=False):
         pos_int_override (bool): if True, overrides the peak center as the median q-value of the array, and intensity as the intensity at that q.
     '''
     # example guess: [500.,0.00665,0.0002] [int, q, width]
-    x = x.dropna('q')
+    x = x.dropna('q').squeeze()
     if guess == None:
         guess = [500.,0.00665,0.0002]
         pos_int_override=True
@@ -117,7 +117,7 @@ def fit_lorentz_bg(x,guess=None,pos_int_override=False,silent=False):
         pos_int_override (bool): if True, overrides the peak center as the median q-value of the array, and intensity as the intensity at that q.
     '''
     # example guess: [500.,0.00665,0.0002,0] [int, q, width, bg]
-    x = x.dropna('q')
+    x = x.dropna('q').squeeze()
     if guess == None:
         guess = [500.,0.00665,0.0002,0]
         pos_int_override=True

--- a/tests/test_Fitting_lorentz.py
+++ b/tests/test_Fitting_lorentz.py
@@ -1,0 +1,55 @@
+import sys
+sys.path.append("src/")
+
+import numpy as np
+import xarray as xr
+from PyHyperScattering import Fitting
+
+q = np.linspace(0.005, 0.007, 50)
+AMPLITUDE = 5.0
+CENTER = 0.006
+WIDTH = 0.0002
+BACKGROUND = 0.1
+
+lorentz_da = xr.DataArray(
+    Fitting.lorentz(q, AMPLITUDE, CENTER, WIDTH),
+    coords={"q": q},
+    dims=["q"],
+)
+lorentz_bg_da = xr.DataArray(
+    Fitting.lorentz_w_flat_bg(q, AMPLITUDE, CENTER, WIDTH, BACKGROUND),
+    coords={"q": q},
+    dims=["q"],
+)
+
+def test_fit_lorentz():
+    res = Fitting.fit_lorentz(
+        lorentz_da, guess=[AMPLITUDE * 0.9, CENTER * 1.01, WIDTH * 1.1], silent=True
+    )
+    assert np.isclose(res.intensity.mean(), AMPLITUDE, rtol=1e-5)
+    assert np.isclose(res.pos.mean(), CENTER, rtol=1e-5)
+    assert np.isclose(res.width.mean(), WIDTH, rtol=1e-5)
+
+def test_fit_lorentz_bg():
+    res = Fitting.fit_lorentz_bg(
+        lorentz_bg_da,
+        guess=[AMPLITUDE * 0.9, CENTER * 1.01, WIDTH * 1.1, BACKGROUND * 0.8],
+        silent=True,
+    )
+    assert np.isclose(res.intensity.mean(), AMPLITUDE, rtol=1e-5)
+    assert np.isclose(res.pos.mean(), CENTER, rtol=1e-5)
+    assert np.isclose(res.width.mean(), WIDTH, rtol=1e-5)
+    assert np.isclose(res.bg.mean(), BACKGROUND, rtol=1e-5)
+
+def test_fitting_apply_with_stacked_dimension():
+    stacked = xr.concat([lorentz_bg_da, lorentz_bg_da], dim="replicate").assign_coords(
+        replicate=["r1", "r2"]
+    )
+    result = stacked.fit.apply(
+        Fitting.fit_lorentz_bg,
+        guess=[AMPLITUDE * 0.9, CENTER * 1.01, WIDTH * 1.1, BACKGROUND * 0.8],
+        silent=True,
+    )
+    assert list(result.dims) == ["replicate"]
+    assert list(result.coords["replicate"].values) == ["r1", "r2"]
+


### PR DESCRIPTION
## Summary
- handle dimension squeezing in `fit_lorentz` and `fit_lorentz_bg`
- add unit tests verifying lorentz fitting and use of `Fitting.apply`

## Testing
- `pytest tests/test_Fitting_lorentz.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6847a1f89904832b9ea45c2a8af29e64