### PR TITLE
Add PFGeneralIntegrator sigma broadcast fix and basic test

### DIFF
--- a/src/PyHyperScattering/PFGeneralIntegrator.py
+++ b/src/PyHyperScattering/PFGeneralIntegrator.py
@@ -298,7 +298,7 @@ class PFGeneralIntegrator:
                     )
         if self.return_sigma:
             sigma = xr.ones_like(res)
-            sigma.values = frame.sigma
+            sigma.data = np.broadcast_to(frame.sigma, sigma.shape)
             res = res.to_dataset(name='I')
             res['dI'] = sigma
         return res

--- a/tests/test_pf_general_integrator_basic.py
+++ b/tests/test_pf_general_integrator_basic.py
@@ -1,0 +1,29 @@
+import xarray as xr
+import numpy as np
+from PyHyperScattering.PFGeneralIntegrator import PFGeneralIntegrator
+
+
+def test_single_image_dataset():
+    npts = 123
+    img = xr.DataArray(np.ones((10, 10)), dims=["pix_y", "pix_x"])
+    integ = PFGeneralIntegrator(
+        maskmethod="none",
+        geomethod="none",
+        do_1d_integration=True,
+        return_sigma=True,
+        npts=npts,
+        energy=1000,
+    )
+    integ.calibrationFromNikaParams(
+        distance=1000,
+        bcx=5,
+        bcy=5,
+        tiltx=0,
+        tilty=0,
+        pixsizex=100,
+        pixsizey=100,
+    )
+    result = integ.integrateSingleImage(img)
+    assert isinstance(result, xr.Dataset)
+    assert set(result.data_vars) == {"I", "dI"}
+    assert len(result.coords["q"]) == npts


### PR DESCRIPTION
## Summary
- fix sigma assignment in `PFGeneralIntegrator.integrateSingleImage`
- add regression test covering 1D integration with sigma output

## Testing
- `pytest tests/test_pf_general_integrator_basic.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6847a1fa3410832b9b6241d5865a290f